### PR TITLE
Error handling for blank teacher

### DIFF
--- a/dailyClassReminder.py
+++ b/dailyClassReminder.py
@@ -198,7 +198,7 @@ for teacher in TEACHERS:
     # Reformat date for email subject
     formatted_today = TODAY.strftime("%B %d")
 
-    teacher_first_name = teacher[: teacher.index(" ")]
+    teacher_first_name = teacher.split(' ')[0] if teacher else 'N/A'
 
     # Compose email
     email_msg = f"""

--- a/dailyClassReminder.py
+++ b/dailyClassReminder.py
@@ -76,7 +76,7 @@ ALREADY_SENT = []
 # Begin gathering data for emailing each teacher
 # Send each teacher an email reminder about classes they are scheduled to teach
 for teacher in TEACHERS:
-    if teacher is None:
+    if not teacher:
         logging.info("WARNING:  No teacher assigned!")
         TEACHER_EMAILS[None] = "classes@asmbly.org"
     if teacher in ALREADY_SENT:

--- a/dailyClassReminder.py
+++ b/dailyClassReminder.py
@@ -78,7 +78,7 @@ ALREADY_SENT = []
 for teacher in TEACHERS:
     if not teacher:
         logging.info("WARNING:  No teacher assigned!")
-        TEACHER_EMAILS[None] = "classes@asmbly.org"
+        TEACHER_EMAILS[teacher] = "classes@asmbly.org"
     if teacher in ALREADY_SENT:
         logging.info("Already emailed %s", teacher)
         continue


### PR DESCRIPTION
When a teacher isn't assigned to a class yet, the "Event Topic" in Neon will be blank. Because the result is an empty string, not `None`, the script doesn't catch the error, and just silently fails. This update catches any falsy value for the event topic, and should send an email to classes@asmbly.org.

As it currently stands, the subject line will be "Failed Class Reminder - ". See line 224 of the script - `TEACHER_EMAILS['']` will raise a KeyError. We could fix this by changing line 224 to `TEACHER_EMAILS.get(teacher)` (which would also make the overall script a bit safer), but I'm not sure what the desired behavior is yet.