### PR TITLE
Safer data handling around phone number (take 2)

### DIFF
--- a/dailyClassReminder.py
+++ b/dailyClassReminder.py
@@ -138,15 +138,12 @@ for teacher in TEACHERS:
                 # but these aren't accessible from the API, so we will just use the info from the main account
                 acct_info = neon.getAccountIndividual(acct_id)
                 email = acct_info["individualAccount"]["primaryContact"]["email1"]
-                phone = ""
-                try:
-                    phone = acct_info["individualAccount"]["primaryContact"][
-                        "addresses"
-                    ][0]["phone1"]
-                except KeyError:
-                    phone = acct_info["individualAccount"]["primaryContact"][
-                        "addresses"
-                    ][1]["phone1"]
+                addresses = acct_info["individualAccount"]["primaryContact"]["addresses"]
+                # Get all phone numbers in the address entries, then use the first non-None result
+                phones = [addr.get('phone1') for addr in addresses]
+                phone = [p for p in phones if p][0]
+                if not phone:
+                    phone = "N/A"
 
                 # Build a dictionary list of attendee names under this registration
                 attendee_list = {"name": [], "email": email, "phone": phone}


### PR DESCRIPTION
This script previously assumed that a user would have at least one of their first two address entries with a phone number. Because of this, the script would crash if it came upon a user without a phone number (or at least, without a phone number in the first two entries).

This change iterates through the entire list of addresses and finds the first entry with a phone number, then uses that. If no phone numbers are found, it just uses the string "N/A".