### PR TITLE
Add mock users, basic test for updating Alta groups

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,13 @@
 certifi==2025.6.15
 charset-normalizer==3.4.2
+coverage==7.10.6
 idna==3.10
 iniconfig==2.1.0
 packaging==25.0
 pluggy==1.6.0
 Pygments==2.19.2
 pytest==8.4.1
+pytest-mock==3.14.1
+pytz==2025.2
 requests==2.32.4
 urllib3==2.5.0

--- a/tests/mock_alta_users.py
+++ b/tests/mock_alta_users.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Self
+import random
 
 ##### Needed for importing script files (as opposed to classes)
 import sys
@@ -6,15 +7,13 @@ import os
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 ##### End block
 
-# import openPathUtil
-
 class MockAltaUserBuilder():
     def __init__(self):
         self.reset()
 
     def reset(self):
-        # Alta IDs are only numeric
-        self._alta_id = 123
+        # Alta IDs are only numeric - pick an integer between 1 and 100,000
+        self._alta_id = random.randint(1, 100000)
         self._name = "John Doe"
         self._email = "john@example.com"
         self._groups = []

--- a/tests/mock_alta_users.py
+++ b/tests/mock_alta_users.py
@@ -1,0 +1,34 @@
+from typing import List
+
+##### Needed for importing script files (as opposed to classes)
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+##### End block
+
+# import openPathUtil
+
+class MockAltaUserBuilder():
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        # Alta IDs are only numeric
+        self._alta_id = 123
+        self._name = "John Doe"
+        self._email = "john@example.com"
+        self._groups = []
+        return self
+
+    def with_groups(self, groups: List[str]):
+        self._groups.extend(groups)
+        return self
+
+    def build(self):
+        return {
+            'OpenPathID': self._alta_id,
+            'name': self._name,
+            'email': self._email,
+            'groups': self._groups,
+        }
+

--- a/tests/mock_alta_users.py
+++ b/tests/mock_alta_users.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, Dict, List, Self
 
 ##### Needed for importing script files (as opposed to classes)
 import sys
@@ -20,11 +20,15 @@ class MockAltaUserBuilder():
         self._groups = []
         return self
 
-    def with_groups(self, groups: List[str]):
+    def with_groups(self, groups: List[str]) -> Self:
         self._groups.extend(groups)
         return self
 
-    def build(self):
+    def with_id(self, alta_id: int) -> Self:
+        self._alta_id = alta_id
+        return self
+
+    def build(self) -> Dict[str, Any]:
         return {
             'OpenPathID': self._alta_id,
             'name': self._name,

--- a/tests/mock_neon_users.py
+++ b/tests/mock_neon_users.py
@@ -24,8 +24,7 @@ class MockNeonUserBuilder():
         self._name = "John Doe"
         self._email = "john@example.com"
         self._individual_types = []
-        # TODO: Does this need to match the value in the MockAltaUserBuilder?
-        self._open_path_id = '123'
+        self._open_path_id = random.randint(1, 100000)
         return self
 
     def with_type(self, neon_type):

--- a/tests/mock_neon_users.py
+++ b/tests/mock_neon_users.py
@@ -1,0 +1,35 @@
+##### Needed for importing script files (as opposed to classes)
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+##### End block
+
+import neonUtil
+
+class MockNeonUserBuilder():
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        # TODO: Determine whether Neon IDs are alphanumeric or just numeric
+        self._id = '123ab'
+        self._name = "John Doe"
+        self._email = "john@example.com"
+        self._individual_types = []
+        # TODO: Does this need to match the value in the MockAltaUserBuilder?
+        self._open_path_id = '123'
+        return self
+
+    def add_type(self, neon_type):
+        self._individual_types.append({'name': neon_type})
+        return self
+
+    def build(self):
+        return {
+            'id': self._id,
+            'name': self._name,
+            'email': self._email,
+            'individualTypes': self._individual_types,
+            'OpenPathID': self._open_path_id,
+        }
+

--- a/tests/mock_neon_users.py
+++ b/tests/mock_neon_users.py
@@ -1,3 +1,7 @@
+from typing import Self
+import string
+import random
+
 ##### Needed for importing script files (as opposed to classes)
 import sys
 import os
@@ -10,9 +14,13 @@ class MockNeonUserBuilder():
     def __init__(self):
         self.reset()
 
+    def random_alphanumeric(self, length):
+        characters = string.ascii_letters + string.digits
+        return ''.join(random.choice(characters) for _ in range(length))
+
     def reset(self):
         # TODO: Determine whether Neon IDs are alphanumeric or just numeric
-        self._id = '123ab'
+        self._id = self.random_alphanumeric(6)
         self._name = "John Doe"
         self._email = "john@example.com"
         self._individual_types = []
@@ -20,8 +28,12 @@ class MockNeonUserBuilder():
         self._open_path_id = '123'
         return self
 
-    def add_type(self, neon_type):
+    def with_type(self, neon_type):
         self._individual_types.append({'name': neon_type})
+        return self
+
+    def with_alta_id(self, alta_id: int) -> Self:
+        self._open_path_id = alta_id
         return self
 
     def build(self):

--- a/tests/test_openPathUpdateAll.py
+++ b/tests/test_openPathUpdateAll.py
@@ -1,0 +1,40 @@
+import pytest
+import pdb
+
+
+##### Needed for importing script files (as opposed to classes)
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+##### End block
+
+import openPathUpdateAll
+from mock_neon_users import MockNeonUserBuilder
+from mock_alta_users import MockAltaUserBuilder
+
+class TestOpenPathUpdateAll:
+    def test_update_all(self, mocker):
+        mock_func = mocker.patch('openPathUtil.getAllUsers')
+        mock_alta_account = (MockAltaUserBuilder()
+                             .with_groups(['test_group'])
+                             .build()
+                            )
+        alta_accts = {}
+        # This puts the accounts into the format that the scripts are
+        # expecting: Each account is a dict, and they're contained within a
+        # dict, indexed by the account ID. For example:
+        # { '123': { 'OpenPathID': '123' } }
+        alta_accts[mock_alta_account['OpenPathID']] = mock_alta_account
+        mock_func.return_value = alta_accts
+
+        accounts = {}
+        acct = (MockNeonUserBuilder()
+            .build())
+        accounts[acct['id']] = acct
+
+        mock_update_groups = mocker.patch('openPathUtil.updateGroups')
+        expected_calls = [
+            mocker.call(acct, openPathGroups=['test_group']),
+        ]
+        openPathUpdateAll.openPathUpdateAll(accounts)
+        mock_update_groups.assert_has_calls(expected_calls)

--- a/tests/test_openPathUpdateAll.py
+++ b/tests/test_openPathUpdateAll.py
@@ -1,6 +1,5 @@
 import pytest
-import pdb
-
+from typing import Tuple
 
 ##### Needed for importing script files (as opposed to classes)
 import sys
@@ -13,28 +12,47 @@ from mock_neon_users import MockNeonUserBuilder
 from mock_alta_users import MockAltaUserBuilder
 
 class TestOpenPathUpdateAll:
-    def test_update_all(self, mocker):
-        mock_func = mocker.patch('openPathUtil.getAllUsers')
-        mock_alta_account = (MockAltaUserBuilder()
-                             .with_groups(['test_group'])
-                             .build()
-                            )
-        alta_accts = {}
-        # This puts the accounts into the format that the scripts are
-        # expecting: Each account is a dict, and they're contained within a
-        # dict, indexed by the account ID. For example:
-        # { '123': { 'OpenPathID': '123' } }
-        alta_accts[mock_alta_account['OpenPathID']] = mock_alta_account
-        mock_func.return_value = alta_accts
+    def _create_alta_accounts(self, *group_lists):
+        mock_alta_accounts = {}
+        for i, groups in enumerate(group_lists):
+            # Cannot have a user with id 0
+            mock_alta_account = (MockAltaUserBuilder()
+                                 .with_id(i+1)
+                                 .with_groups(groups)
+                                 .build()
+                                )
+            mock_alta_accounts[mock_alta_account['OpenPathID']] = mock_alta_account
+        return mock_alta_accounts
 
-        accounts = {}
-        acct = (MockNeonUserBuilder()
-            .build())
-        accounts[acct['id']] = acct
+    def _create_neon_accounts(self, alta_ids):
+        mock_neon_accounts = {}
+        for aid in alta_ids:
+            mock_neon_acct = (MockNeonUserBuilder()
+                              .with_alta_id(aid)
+                              .build())
+            mock_neon_accounts.update({mock_neon_acct['id']: mock_neon_acct})
+        return mock_neon_accounts
 
-        mock_update_groups = mocker.patch('openPathUtil.updateGroups')
+    @pytest.fixture
+    def setup_mocks(self, mocker):
+        return {
+            'getAllUsers': mocker.patch('openPathUtil.getAllUsers'),
+            'updateGroups': mocker.patch('openPathUtil.updateGroups'),
+        }
+
+    def test_update_all(self, mocker, setup_mocks):
+        # Create two users with accounts in Alta and in Neon (linked by OpenPathID)
+        test_groups = (['test_group'], ['test_group_2'])
+        alta_accts = self._create_alta_accounts(*test_groups)
+        neon_accounts = self._create_neon_accounts(alta_accts.keys())
+
+        setup_mocks['getAllUsers'].return_value = alta_accts
+
         expected_calls = [
-            mocker.call(acct, openPathGroups=['test_group']),
+            mocker.call(neon_acct, openPathGroups=group_list)
+            for neon_acct, group_list
+            in zip(neon_accounts.values(), test_groups)
         ]
-        openPathUpdateAll.openPathUpdateAll(accounts)
-        mock_update_groups.assert_has_calls(expected_calls)
+
+        openPathUpdateAll.openPathUpdateAll(neon_accounts)
+        setup_mocks['updateGroups'].assert_has_calls(expected_calls)

--- a/tests/test_openPathUpdateAll.py
+++ b/tests/test_openPathUpdateAll.py
@@ -17,10 +17,10 @@ class TestOpenPathUpdateAll:
         for i, groups in enumerate(group_lists):
             # Cannot have a user with id 0
             acct = (MockAltaUserBuilder()
-                                 .with_id(i+1)
-                                 .with_groups(groups)
-                                 .build()
-                                )
+                    .with_id(i+1)
+                    .with_groups(groups)
+                    .build()
+                   )
             accts[acct['OpenPathID']] = acct
         return accts
 
@@ -28,8 +28,8 @@ class TestOpenPathUpdateAll:
         accts = {}
         for aid in alta_ids:
             acct = (MockNeonUserBuilder()
-                              .with_alta_id(aid)
-                              .build())
+                    .with_alta_id(aid)
+                    .build())
             accts.update({acct['id']: acct})
         return accts
 
@@ -48,16 +48,28 @@ class TestOpenPathUpdateAll:
         }
 
     def test_update_all(self, mocker, setup_mocks):
+        # Create a set of fake accounts in Neon and Alta
         test_groups = (['test_group'], ['test_group_2'])
         (alta_accounts, neon_accounts) = self._create_matching_alta_and_neon_accounts(test_groups)
 
+        # When `openPathUtil.getAllUsers()` is called, return our fake accounts
+        # instead of actually connecting to OpenPath/Alta.
         setup_mocks['getAllUsers'].return_value = alta_accounts
 
+        # Based on the fake user accounts we've just created, figure out what
+        # arguments should be passed in when `openPathUtil.updateGroups` gets
+        # called in openPathUpdateAll.py. We'll then check these arguments
+        # against what actually gets passed in when the openPathUpdateAll
+        # script runs.
         expected_calls = [
             mocker.call(neon_acct, openPathGroups=group_list)
             for neon_acct, group_list
             in zip(neon_accounts.values(), test_groups)
         ]
 
+        # Run the openPathUpdateAll script with our fake accounts.
         openPathUpdateAll.openPathUpdateAll(neon_accounts)
+
+        # Verify that openPathUtil.updateGroups was called with the correct
+        # arguments, based on our fake accounts.
         setup_mocks['updateGroups'].assert_has_calls(expected_calls)


### PR DESCRIPTION
This adds two main pieces of code - the MockNeonUserBuilder and the MockAltaUserBuilder. The Builder pattern allows us to create complex objects (like fake user accounts) in a relatively readable way, and we can then use those mock accounts to test out the behavior of real functions without needing to connect to either Alta or Neon.

This also adds a basic test: it ensures that, when a user's Neon and Alta accounts are linked via the correct OpenPathID, then the user's groups (from Alta) will be correctly updated into Neon.