### PR TITLE
Add tests for dailyClassReminder.py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
-        run: pip install pytest
+        run: pip install pytest requests
       - name: Run pytest
         run: pytest
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
-        run: pip install pytest requests
+        run: pip install pytest pytest-mock requests
       - name: Run pytest
         run: pytest
 on:

--- a/dailyClassReminder.py
+++ b/dailyClassReminder.py
@@ -59,16 +59,16 @@ OUTPUT_FIELDS = [
     "Waiting List Status",
 ]
 
-RESPONSE_EVENTS = neon.postEventSearch(SEARCH_FIELDS, OUTPUT_FIELDS)
-
-
-# Remove duplicates in the list of teachers
-TEACHERS = {item.get("Event Topic") for item in RESPONSE_EVENTS["searchResults"]}
+def get_response_events(search_fields, output_fields):
+    return neon.postEventSearch(search_fields, output_fields)
 
 # Import teacher contact info
-CONTACT_INFO = "teachers.json"
-with open(CONTACT_INFO, "r", encoding="utf-8") as f:
-    TEACHER_EMAILS = json.load(f)
+def get_teacher_contact_info():
+    CONTACT_INFO = "teachers.json"
+    teacher_emails = {}
+    with open(CONTACT_INFO, "r", encoding="utf-8") as f:
+        teacher_emails = json.load(f)
+    return teacher_emails
 
 # For use if script ran and failed to complete
 ALREADY_SENT = []
@@ -76,6 +76,12 @@ ALREADY_SENT = []
 # Begin gathering data for emailing each teacher
 # Send each teacher an email reminder about classes they are scheduled to teach
 def main():
+    TEACHER_EMAILS = get_teacher_contact_info()
+    RESPONSE_EVENTS = get_response_events(SEARCH_FIELDS, OUTPUT_FIELDS)
+
+    # Remove duplicates in the list of teachers
+    TEACHERS = {item.get("Event Topic") for item in RESPONSE_EVENTS["searchResults"]}
+
     for teacher in TEACHERS:
         try:
             if not teacher:

--- a/tests/mock_config_call.py
+++ b/tests/mock_config_call.py
@@ -1,0 +1,16 @@
+# In tests, mock_config should be imported before any script that uses the
+# config file. This will mock out the content of those files and allow tests to
+# pass. If this file is not imported, then tests will fail with "No Module
+# named 'config'" in the pipeline.
+
+import sys
+from unittest.mock import MagicMock, patch
+
+# Create a mock config module
+mock_config = MagicMock()
+mock_config.N_APIkey = "fake_neon_key"
+mock_config.N_APIuser = "fake_neon_user"
+
+# Inject it into sys.modules BEFORE importing your script
+sys.modules['config'] = mock_config
+

--- a/tests/mock_events.py
+++ b/tests/mock_events.py
@@ -3,17 +3,11 @@ from unittest.mock import patch, MagicMock, call
 from typing import Dict, List, Any
 import datetime
 
-##### Needed for importing script files (as opposed to classes)
-import sys
-import os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-##### End block
-
 
 class MockEventBuilder:
     def __init__(self):
         self.reset()
-    
+
     def reset(self):
         self._event_id = "12345"
         self._event_name = "Test Class"
@@ -25,24 +19,24 @@ class MockEventBuilder:
         self._registrants = 5
         self._registration_count = 5
         return self
-    
+
     def with_teacher(self, teacher_name: str):
         self._event_topic = teacher_name
         return self
-    
+
     def with_date(self, date: str):
         self._event_start_date = date
         self._event_end_date = date
         return self
-    
+
     def with_event_id(self, event_id: str):
         self._event_id = event_id
         return self
-    
+
     def with_event_name(self, name: str):
         self._event_name = name
         return self
-    
+
     def build(self) -> Dict[str, Any]:
         return {
             "Event ID": self._event_id,

--- a/tests/mock_events.py
+++ b/tests/mock_events.py
@@ -1,0 +1,59 @@
+import pytest
+from unittest.mock import patch, MagicMock, call
+from typing import Dict, List, Any
+import datetime
+
+##### Needed for importing script files (as opposed to classes)
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+##### End block
+
+
+class MockEventBuilder:
+    def __init__(self):
+        self.reset()
+    
+    def reset(self):
+        self._event_id = "12345"
+        self._event_name = "Test Class"
+        self._event_topic = "John Doe"  # Teacher name
+        self._event_start_date = datetime.date.today().isoformat()
+        self._event_start_time = "10:00:00"
+        self._event_end_date = datetime.date.today().isoformat()
+        self._event_end_time = "12:00:00"
+        self._registrants = 5
+        self._registration_count = 5
+        return self
+    
+    def with_teacher(self, teacher_name: str):
+        self._event_topic = teacher_name
+        return self
+    
+    def with_date(self, date: str):
+        self._event_start_date = date
+        self._event_end_date = date
+        return self
+    
+    def with_event_id(self, event_id: str):
+        self._event_id = event_id
+        return self
+    
+    def with_event_name(self, name: str):
+        self._event_name = name
+        return self
+    
+    def build(self) -> Dict[str, Any]:
+        return {
+            "Event ID": self._event_id,
+            "Event Name": self._event_name,
+            "Event Topic": self._event_topic,
+            "Event Start Date": self._event_start_date,
+            "Event Start Time": self._event_start_time,
+            "Event End Date": self._event_end_date,
+            "Event End Time": self._event_end_time,
+            "Event Registration Attendee Count": self._registration_count,
+            "Registrants": self._registrants,
+            "Hold To Waiting List": "No",
+            "Waiting List Status": "Open"
+        }

--- a/tests/test_dailyClassReminders.py
+++ b/tests/test_dailyClassReminders.py
@@ -10,19 +10,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 ##### End block
 
 from mock_events import MockEventBuilder
-
-# ======================= Note on Imports ===================================
-# In dailyClassReminder.py, we call the Neon API and store the result in a
-# global variable. This happens outside of a function, so the code runs
-# immediately when the script is imported. We need to mock out that API call,
-# so we can't import the script until after we have our mocks in place. This
-# results in an import step within each test function.
-# 
-# In the future, if we remove the global variables and put the API calls inside
-# a function, we'll be able to import dailyClassReminder normally.
-
 import dailyClassReminder 
-# ======================= End Note on Imports ================================
 
 
 class TestClassReminders:

--- a/tests/test_dailyClassReminders.py
+++ b/tests/test_dailyClassReminders.py
@@ -1,0 +1,188 @@
+import pytest
+from unittest.mock import patch, MagicMock, call
+from typing import Dict, List, Any
+import datetime
+
+##### Needed for importing script files (as opposed to classes)
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+##### End block
+
+from mock_events import MockEventBuilder
+
+# ======================= Note on Imports ===================================
+# In dailyClassReminder.py, we call the Neon API and store the result in a
+# global variable. This happens outside of a function, so the code runs
+# immediately when the script is imported. We need to mock out that API call,
+# so we can't import the script until after we have our mocks in place. This
+# results in an import step within each test function.
+# 
+# In the future, if we remove the global variables and put the API calls inside
+# a function, we'll be able to import dailyClassReminder normally.
+
+import dailyClassReminder 
+# ======================= End Note on Imports ================================
+
+
+class TestClassReminders:
+    
+    @pytest.fixture
+    def setup_mocks(self, mocker):
+        """Setup all the mocks needed for testing"""
+        return {
+            'postEventSearch': mocker.patch('helpers.neon.postEventSearch'),
+            'getEventRegistrants': mocker.patch('helpers.neon.getEventRegistrants'),
+            'getEventRegistrantCount': mocker.patch('helpers.neon.getEventRegistrantCount'),
+            'getAccountIndividual': mocker.patch('helpers.neon.getAccountIndividual'),
+            # I think this is because we call the method directly in dailyClassReminder.
+            # That is, we call `sendMIMEmessage` rather than `gmail.sendMIMEmessage`.
+            'sendMIMEmessage': mocker.patch('dailyClassReminder.sendMIMEmessage'),
+            'open': mocker.patch('builtins.open', mocker.mock_open(
+                read_data='{"John Doe": "john@example.com", "Jane Smith": "jane@example.com"}'
+            ))
+        }
+    
+    def _create_mock_events(self, teacher_events: Dict[str, List[str]]) -> List[Dict]:
+        """
+        Create mock events for testing
+        teacher_events: Dict mapping teacher names to list of event names
+        """
+        events = []
+        event_id = 1
+        
+        for teacher, event_names in teacher_events.items():
+            for event_name in event_names:
+                event = (MockEventBuilder()
+                        .with_teacher(teacher)
+                        .with_event_name(event_name)
+                        .with_event_id(str(event_id))
+                        .build())
+                events.append(event)
+                event_id += 1
+        
+        return events
+    
+    def _setup_mock_registrations(self, mocks):
+        """Setup mock registration data"""
+        mocks['getEventRegistrants'].return_value = {
+            "eventRegistrations": [
+                {
+                    "registrantAccountId": "123",
+                    "tickets": [{
+                        "attendees": [{
+                            "firstName": "Test",
+                            "lastName": "Student",
+                            "registrationStatus": "SUCCEEDED"
+                        }]
+                    }]
+                }
+            ]
+        }
+        
+        mocks['getEventRegistrantCount'].return_value = 1
+        
+        mocks['getAccountIndividual'].return_value = {
+            "individualAccount": {
+                "primaryContact": {
+                    "email1": "student@example.com",
+                    "addresses": [{"phone1": "555-1234"}]
+                }
+            }
+        }
+    
+    def test_no_duplicate_emails_single_teacher_multiple_events(self, setup_mocks):
+        """Test that a teacher with multiple events only gets one email"""
+        mocks = setup_mocks
+        
+        # Create events: John Doe teaching 2 different classes
+        events = self._create_mock_events({
+            "John Doe": ["Woodworking 101", "Advanced Woodworking"]
+        })
+        
+        mocks['postEventSearch'].return_value = {"searchResults": events}
+        self._setup_mock_registrations(mocks)
+        
+        # Run the main function
+        dailyClassReminder.main()
+        
+        # Verify sendMIMEmessage was called exactly once for John Doe
+        assert mocks['sendMIMEmessage'].call_count == 1
+        
+        # Verify the email contains both events
+        email_call = mocks['sendMIMEmessage'].call_args[0][0]
+        email_body = str(email_call.get_payload()[0])
+        
+        assert "Woodworking 101" in email_body
+        assert "Advanced Woodworking" in email_body
+    
+    def test_duplicate_teacher_names_cause_single_email(self, setup_mocks):
+        """Test that duplicate teacher names in search results don't cause duplicate emails"""
+        mocks = setup_mocks
+        
+        # Create duplicate events with same teacher name (simulating the bug condition)
+        events = [
+            MockEventBuilder().with_teacher("John Doe").with_event_name("Class A").with_event_id("1").build(),
+            MockEventBuilder().with_teacher("John Doe").with_event_name("Class A").with_event_id("1").build(),  # Exact duplicate
+            MockEventBuilder().with_teacher("John Doe").with_event_name("Class B").with_event_id("2").build(),
+        ]
+        
+        mocks['postEventSearch'].return_value = {"searchResults": events}
+        self._setup_mock_registrations(mocks)
+        
+        # Run the main function
+        dailyClassReminder.main()
+        
+        # Should still only send one email despite duplicate events
+        assert mocks['sendMIMEmessage'].call_count == 1
+    
+    def test_multiple_teachers_get_separate_emails(self, setup_mocks):
+        """Test that different teachers get separate emails"""
+        mocks = setup_mocks
+        
+        events = self._create_mock_events({
+            "John Doe": ["Woodworking 101"],
+            "Jane Smith": ["Metalworking 101"]
+        })
+        
+        mocks['postEventSearch'].return_value = {"searchResults": events}
+        self._setup_mock_registrations(mocks)
+        
+        # Run the main function
+        dailyClassReminder.main()
+        
+        # Should send two emails, one for each teacher
+        assert mocks['sendMIMEmessage'].call_count == 2
+        
+        # Verify correct recipients
+        email_calls = mocks['sendMIMEmessage'].call_args_list
+        recipients = [call[0][0]['To'] for call in email_calls]
+        
+        assert "john@example.com" in recipients
+        assert "jane@example.com" in recipients
+   
+    @patch('dailyClassReminder.logging')
+    def test_logging_shows_duplicate_detection(self, mock_logging, setup_mocks):
+        """Test that logging helps identify duplicate issues"""
+        mocks = setup_mocks
+        
+        events = self._create_mock_events({
+            "John Doe": ["Class A", "Class B"]
+        })
+        
+        mocks['postEventSearch'].return_value = {"searchResults": events}
+        self._setup_mock_registrations(mocks)
+        
+        # Run the main function
+        dailyClassReminder.main()
+        
+        # Check that logging was called with information about multiple events
+        log_calls = mock_logging.info.call_args_list
+        
+        # Should log that John Doe has 2 events
+        event_count_logged = any([
+            'John Doe' in args and 2 in args
+            for args, _ in log_calls
+        ])
+
+        assert event_count_logged, "Should log the number of events per teacher"

--- a/tests/test_dailyClassReminders.py
+++ b/tests/test_dailyClassReminders.py
@@ -10,6 +10,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 ##### End block
 
 from mock_events import MockEventBuilder
+
+import mock_config_call # Mock out the config module for the gmail helper
 import dailyClassReminder 
 
 


### PR DESCRIPTION
Includes #38.

    This PR adds a MockEventBuilder and a few tests for the
    dailyClassReminder script. All of these tests currently pass, so they
    don't catch the issue where a teacher will be sent multiple emails in
    one day.

    A lot of this is generated by LLM tools (Claude), with some corrections
    made manually.