### PR TITLE
Remove unused imports which cause tests to fail

### DIFF
--- a/openPathUtil.py
+++ b/openPathUtil.py
@@ -2,8 +2,7 @@
 #      Neon API docs - https://developer.neoncrm.com/api-v2/     #
 #################################################################
 
-from curses import use_default_colors
-from os import openpty, environ
+from os import environ
 from pprint import pformat
 from base64 import b64encode
 import datetime, pytz


### PR DESCRIPTION
When tests are run with the default requirements.txt, the tests fail due to missing packages for these imports. The imports don't appear to be used, so they should be safe to remove.