### PR TITLE
Fix #48, #54 by surfacing likely API error conditions to the logs

### DIFF
--- a/helpers/neon.py
+++ b/helpers/neon.py
@@ -1,6 +1,8 @@
 import base64
 import datetime
 import os
+from typing import Any
+
 import requests
 
 if os.environ.get("USER") == "ec2-user" or os.environ.get("LAMBDA_TASK_ROOT"):
@@ -109,9 +111,7 @@ def postEventSearch(searchFields, outputFields, page=0):
     }
 
     url = N_baseURL + resourcePath + queryParams
-    responseEvents = apiCall(httpVerb, url, data, N_headers).json()
-
-    return responseEvents
+    return neonSearch(url, data, httpVerb)
 
 
 # Get registrations for a single event by event ID
@@ -189,11 +189,8 @@ def postOrderSearch(searchFields, outputFields):
         "outputFields": outputFields,
         "pagination": {"currentPage": 0, "pageSize": 200},
     }
-
     url = N_baseURL + resourcePath + queryParams
-    responseEvents = apiCall(httpVerb, url, data, N_headers).json()
-
-    return responseEvents
+    return neonSearch(url, data, httpVerb)
 
 
 # Get possible search fields for POST to /accounts/search
@@ -234,8 +231,21 @@ def postAccountSearch(searchFields, outputFields):
     }
 
     url = N_baseURL + resourcePath + queryParams
-    responseEvents = apiCall(httpVerb, url, data, N_headers).json()
+    return neonSearch(url, data, httpVerb)
 
+
+def neonSearch(url: str, data: dict[str, Any], httpVerb: str) -> Any:
+    response = apiCall(httpVerb, url, data, N_headers)
+    response.raise_for_status()
+
+    responseEvents = response.json()
+
+    # Validate response structure
+    if not isinstance(responseEvents, dict) or "searchResults" not in responseEvents:
+        raise ValueError(
+            f"POST {url} returned unexpected response type {type(responseEvents).__name__}. "
+            f"Expected dict with 'searchResults' key, got: {responseEvents}"
+        )
     return responseEvents
 
 


### PR DESCRIPTION
# Fix for GitHub Issues #48 and #54

## Problem Summary

Both issues reported the same error in `dailyClassChecker.py` and `classFeedbackAutomation.py`:

```
TypeError: list indices must be integers or slices, not str
```

Occurring at line:
```python
RESPONSE_EVENTS = neon.postEventSearch(SEARCH_FIELDS, OUTPUT_FIELDS)["searchResults"]
```

## Root Cause

According to the [Neon CRM API documentation](https://developer.neoncrm.com/api-v2/#/Events/searchUsingPOST_3), the `/events/search` endpoint should **always** return:

```json
{
  "searchResults": [...],
  "pagination": {...}
}
```

However, when the API encounters certain error conditions (rate limiting, validation errors, etc.), it may return HTTP 200 with an **error response in a different format**, such as:
- An empty list: `[]`
- An error list: `[{"errorMessage": "..."}]`

When the `response.json()` call parses these error responses, they become Python lists. Then trying to access `["searchResults"]` on a list fails with the exact error observed.

## The Fix

Modified three functions in `helpers/neon.py` to add proper error handling:

1. **`postEventSearch()`** (line 103)
2. **`postOrderSearch()`** (line 197)
3. **`postAccountSearch()`** (line 259)

Each function now:

1. ✅ Checks the HTTP status code before parsing JSON
2. ✅ Validates that the response is a dictionary (not a list)
3. ✅ Validates that the dictionary contains the expected `searchResults` key
4. ✅ Raises a descriptive `ValueError` with the actual response content if validation fails

