### PR TITLE
Add warning for legacy event webhooks from Neon

### DIFF
--- a/alta_open_lambda/lambda_function.py
+++ b/alta_open_lambda/lambda_function.py
@@ -230,6 +230,14 @@ def lambda_handler(event: dict, _: dict) -> None:
     if not (event_trigger := neon_response.get("eventTrigger")):
         return
 
+    # This will be read as a string, not a boolean. Since we're only using this
+    # as a temporary measure to migrate off the legacy webhooks, I don't think
+    # we need to worry about casting into the correct data type.
+    legacy = neon_response.get('customParameters', {}).get('legacy')
+    if legacy is not None and legacy == 'true':
+        logger.warning('LEGACY EVENT DETECTED')
+        logger.warning('This type of webhook will be deprecated soon - please update your webhook.')
+
     neon_id = None
 
     match event_trigger:


### PR DESCRIPTION
This doesn't block anything yet, it just logs a warning for legacy webhooks.