### PR TITLE
Fix #95 - Neon HTTP 222 error

### DIFF
--- a/neonUtil.py
+++ b/neonUtil.py
@@ -268,7 +268,11 @@ def getMemberById(id: int, detailed=False):
     url = N_baseURL + f"/accounts/{id}"
     response = requests.get(url, headers=N_headers)
 
-    if response.status_code != 200:
+    # Neon returns a 222 when an account has been merged into another count.
+    # This still works, but can cause confusion.
+    if response.status_code == 222:
+        logging.warning(f"Account {id} has been merged with another account. Please update anywhere still using the old id.")
+    elif response.status_code != 200:
         raise ValueError(f"Get {url} returned status code {response.status_code}")
 
     account = response.json().get("individualAccount")


### PR DESCRIPTION
Reference: https://developer.neoncrm.com/accounts/#handling-http-222

Neon accounts can frequently be merged with other accounts for a variety of reasons, and after they're merged, both account ids will still work to reference the account. Fetching the new account id will return an HTTP 200 (OK), but fetching the old account id will return an HTTP 222. We only consider HTTP 200 to be a success, so this causes an error whenever we use the old account id.

The only logs that I see this is are when a merge event happens and then tries to update the old account. According to Neon's docs, this should still be fine, and we technically don't ever need to update. This PR downgrades this to a warning instead of an error.

I wasn't able to find any instances of an old account id being used after the merge event. If we do see any instances of that in the future, we'll need to investigate to see where the old id is being pulled from, and then update that source. However, this change makes it so that any updates we're trying to make will still be applied to the account, and we can debug the old account id whenever convenient.