### PR TITLE
Fix "NoneType" error in Lambda logs

### DIFF
--- a/alta_open_lambda/lambda_function.py
+++ b/alta_open_lambda/lambda_function.py
@@ -233,7 +233,10 @@ def lambda_handler(event: dict, _: dict) -> None:
     # This will be read as a string, not a boolean. Since we're only using this
     # as a temporary measure to migrate off the legacy webhooks, I don't think
     # we need to worry about casting into the correct data type.
-    legacy = neon_response.get('customParameters', {}).get('legacy')
+    legacy = None
+    parameters = neon_response.get('customParameters')
+    if parameters is not None:
+        legacy = parameters.get('legacy')
     if legacy is not None and legacy == 'true':
         logger.warning('LEGACY EVENT DETECTED')
         logger.warning('This type of webhook will be deprecated soon - please update your webhook.')


### PR DESCRIPTION
The alta-open-update lambda is throwing a ton of errors around this line
- somehow, `neon_response.get('customParameters' {})` seems to be returning a None value, rather than either a real result or an empty dictionary.

I'm not sure exactly under which conditions we'll see this happen, but this diff should prevent it from causing the lambda to error out. This may have prevented a couple members' alta open access from renewing - see the following Slack thread for details: https://asmbly-makerspace.slack.com/archives/C0220TMEW8G/p1780068969532709 